### PR TITLE
Update to v2.0.1

### DIFF
--- a/recipes/metasnv/meta.yaml
+++ b/recipes/metasnv/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.0.0" %}
-{% set sha256 = "cc2f729d596e77e04de5db94ebf607e81c8466de46b1e0a15a7dd0fade9d1af1" %}
+{% set version = "2.0.1" %}
+{% set sha256 = "a1c929b4bd0042628f9ede11d9adcabc9206be3f4274d0343292154fd8a40f56" %}
 
 package:
   name: metasnv
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [py2k or py36]
-  number: 1
+  number: 0
 
 requirements:
   build:
@@ -32,7 +32,7 @@ requirements:
     - numpy
     - pandas
     - htslib
-    - samtools
+    - samtools >=1.12
     - zlib
     - r-base >=4.0
     - bioconductor-biocparallel >=1.26


### PR DESCRIPTION
metaSNV 2.0.1 is now available. Updating from 2.0.0 with mac os bug fixes